### PR TITLE
Tweak cask install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ sudo apt-get install openjdk-8-jdk
 
 ```bash
 brew tap AdoptOpenJDK/openjdk
-brew cask install adoptopenjdk8
+brew install --cask adoptopenjdk8 #or `brew cask install adoptopenjdk8` for brew version < 3.
 ```
 
 #### On Windows:


### PR DESCRIPTION
👋🏼 team. Thank you for this starter repo. Since [3.0](https://github.com/Homebrew/brew/pull/10397/files#) the command `brew cask` has been deleted, and it seems like `brew install --cask adoptopenjdk8` is the way to do it.