### PR TITLE
don't add 'train' to the file prefixes

### DIFF
--- a/iglu/data/pipeline.py
+++ b/iglu/data/pipeline.py
@@ -88,7 +88,6 @@ class IGLUDataPipeline(MineRLDataPipeline):
     @staticmethod
     def _get_all_valid_recordings(path):
         path = pathlib.Path(path)
-        path = path / 'train'
         sessions = path.glob('*-c*.mp4')
         sessions = [str(s)[:-len('.mp4')] for s in sessions]
         sessions = np.array(sessions)


### PR DESCRIPTION
The same prefix was not added in DataPipeline.load_data in minerl so the pipeline is looking for files without 'train'

It is easier for now to just specify the path with "train" when laoding.

data = iglu.data.make(data_dir='~/iglu_data/train')